### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "todo_app",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "todo_app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.cmolz.todo.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/Pages/EditTodo.tsx
+++ b/src/Pages/EditTodo.tsx
@@ -15,6 +15,20 @@ const editTodo = () =>{
     const [ done, setDone ] = useState(false);
     const [ changeOnItem, setChangeOnItem ] = useState(false);
     const [ picture, setPicture ] = useState<File | null>(null);
+
+    const validateFile = (file: File): boolean => {
+        const validTypes = ['image/jpeg', 'image/png', 'image/gif'];
+        const maxSize = 5 * 1024 * 1024; // 5MB
+        if (!validTypes.includes(file.type)) {
+            alert('Invalid file type. Please upload an image file (jpeg, png, gif).');
+            return false;
+        }
+        if (file.size > maxSize) {
+            alert('File size exceeds the limit of 5MB.');
+            return false;
+        }
+        return true;
+    };
     const [ pictureName, setPictureName ] = useState('');
     const navigate = useNavigate();
     const { todo_id } = useParams();
@@ -288,7 +302,7 @@ const editTodo = () =>{
                         className="file-input file-input-bordered w-full max-w-xs"
                         accept="image/*"
                         onChange={(e) => {
-                            if (e.target.files) {
+                            if (e.target.files && validateFile(e.target.files[0])) {
                                 setPicture(e.target.files[0]);
                             }
                         }}


### PR DESCRIPTION
Fixes [https://github.com/ConnorMolz/todo_app_v2/security/code-scanning/2](https://github.com/ConnorMolz/todo_app_v2/security/code-scanning/2)

To fix the problem, we need to ensure that the file input is properly validated before creating an object URL. We can add a validation step to check the file type and size before setting the `picture` state. This will help mitigate the risk of XSS by ensuring that only valid image files are processed.

1. Add a validation function to check the file type and size.
2. Update the `onChange` handler for the file input to use this validation function before setting the `picture` state.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
